### PR TITLE
Add transaction counts and tweak some styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import Paper from '@material-ui/core/Paper'
 import TransactionFilter from './components/TransactionFilter';
 import TransactionList from './components/TransactionList';
 import Fetch from './components/Fetch'
-import { list } from './api'
+import { list, count } from './api'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -38,23 +38,37 @@ export default function App() {
     action: list,
     params: {
       sort: `${sort.orderBy},${sort.order}`,
-      ...page, 
+      ...page,
       filterOptions:filter,
       siteKey:'Rdhcya1h7lLN3rcsite' // hard coding the site key for now, should come from parent app
     }
   }
-  
+
+  const countAction = {
+    action: count,
+    params: {
+      sort: `${sort.orderBy},${sort.order}`,
+      ...page,
+      filterOptions: filter,
+      siteKey:'Rdhcya1h7lLN3rcsite'
+    }
+  }
+
   return (
     <div className={classes.root}>
       <Paper className={classes.paper}>
-        <TransactionFilter onApplyFilter={handleApplyFilter}/>
+        <Fetch actions={countAction}>
+          {data => (
+            <TransactionFilter onApplyFilter={handleApplyFilter} resultCounts={data} />
+          )}
+        </Fetch>
         <Fetch actions={listAction}>
           {data => (
-            <TransactionList 
-              page={data.transactions ? data : defaultPage}
-              sort={sort}
-              onChangePage={(newPage) => setPage(newPage)}
-              onRequestSort={(newSort) => setSort(newSort)} />
+              <TransactionList
+                page={data.transactions ? data : defaultPage}
+                sort={sort}
+                onChangePage={(newPage) => setPage(newPage)}
+                onRequestSort={(newSort) => setSort(newSort)} />
           )}
         </Fetch>
       </Paper>

--- a/src/App.js
+++ b/src/App.js
@@ -1,48 +1,47 @@
-import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import Paper from '@material-ui/core/Paper'
-import TransactionFilter from './components/TransactionFilter';
-import TransactionList from './components/TransactionList';
-import Fetch from './components/Fetch'
-import { list, count } from './api'
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Paper from "@material-ui/core/Paper";
+import TransactionFilter from "./components/TransactionFilter";
+import TransactionList from "./components/TransactionList";
+import Fetch from "./components/Fetch";
+import { list, count } from "./api";
 
 const useStyles = makeStyles(theme => ({
   root: {
-    width: '100%',
+    width: "100%"
   },
   paper: {
-    width: '100%',
-    marginBottom: theme.spacing(2),
-  },
+    width: "100%",
+    marginBottom: theme.spacing(2)
+  }
 }));
 
-
 const defaultPage = {
-  "pageNumber": 0,
-  "pageSize": 20,
-  "totalElements": 0,
-  "content": []
-}
+  pageNumber: 0,
+  pageSize: 20,
+  totalElements: 0,
+  content: []
+};
 
 export default function App() {
   const classes = useStyles();
   const [page, setPage] = React.useState({ pageNumber: 0, pageSize: 20 });
-  const [sort, setSort] = React.useState({ order: 'asc', orderBy: 'orderId' });
+  const [sort, setSort] = React.useState({ order: "asc", orderBy: "orderId" });
   const [filter, setFilter] = React.useState();
 
-  const handleApplyFilter = (newFilter) => {
+  const handleApplyFilter = newFilter => {
     setFilter(newFilter);
-  }
+  };
 
   const listAction = {
     action: list,
     params: {
       sort: `${sort.orderBy},${sort.order}`,
       ...page,
-      filterOptions:filter,
-      siteKey:'Rdhcya1h7lLN3rcsite' // hard coding the site key for now, should come from parent app
+      filterOptions: filter,
+      siteKey: "Rdhcya1h7lLN3rcsite" // hard coding the site key for now, should come from parent app
     }
-  }
+  };
 
   const countAction = {
     action: count,
@@ -50,25 +49,29 @@ export default function App() {
       sort: `${sort.orderBy},${sort.order}`,
       ...page,
       filterOptions: filter,
-      siteKey:'Rdhcya1h7lLN3rcsite'
+      siteKey: "Rdhcya1h7lLN3rcsite"
     }
-  }
+  };
 
   return (
     <div className={classes.root}>
       <Paper className={classes.paper}>
         <Fetch actions={countAction}>
           {data => (
-            <TransactionFilter onApplyFilter={handleApplyFilter} resultCounts={data} />
+            <TransactionFilter
+              onApplyFilter={handleApplyFilter}
+              resultCounts={data}
+            />
           )}
         </Fetch>
         <Fetch actions={listAction}>
           {data => (
-              <TransactionList
-                page={data.transactions ? data : defaultPage}
-                sort={sort}
-                onChangePage={(newPage) => setPage(newPage)}
-                onRequestSort={(newSort) => setSort(newSort)} />
+            <TransactionList
+              page={data.transactions ? data : defaultPage}
+              sort={sort}
+              onChangePage={newPage => setPage(newPage)}
+              onRequestSort={newSort => setSort(newSort)}
+            />
           )}
         </Fetch>
       </Paper>

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,6 @@
-import request from './lib/request'
+import request from "./lib/request";
 
-export const DEFAULT_SORT = "orderId,asc"
+export const DEFAULT_SORT = "orderId,asc";
 
 /**
  * Get a paginated list of transactions, returning a promise
@@ -13,42 +13,45 @@ export const DEFAULT_SORT = "orderId,asc"
  *
  * @return {Page} The response data
  */
-export const list = getApiPath('/api/searchTools/transaction');
-export const count = getApiPath('/api/searchTools/transactionCounts');
+export const list = getApiPath("/api/searchTools/transaction");
+export const count = getApiPath("/api/searchTools/transactionCounts");
 
+function getApiPath(path) {
+  return async ({
+    pageNumber = 0,
+    pageSize = 20,
+    sort = DEFAULT_SORT,
+    filterOptions,
+    siteKey
+  }) => {
+    let payload = `{"siteKey":"${siteKey}",`;
 
-  function getApiPath(path) {
-    return async ({ pageNumber = 0, pageSize = 20, sort = DEFAULT_SORT, filterOptions, siteKey }) => {
-    let payload = `{"siteKey":"${siteKey}",`
-
-      if(filterOptions) {
-
-          for (var key in filterOptions) {
-              var value = filterOptions[key];
-              if(value) {
-                  payload = payload.concat(`"${key}":"${value}",`)
-              }
-              console.log(key, value);
-          }
-          payload = payload.concat(`"pageNumber":"${pageNumber}"}`)
-
-          console.debug(`payload 4 is ${payload}` );
-      } else {
-          payload = payload.concat(`"pageNumber":"${pageNumber}"}`)
+    if (filterOptions) {
+      for (var key in filterOptions) {
+        var value = filterOptions[key];
+        if (value) {
+          payload = payload.concat(`"${key}":"${value}",`);
+        }
+        console.log(key, value);
       }
+      payload = payload.concat(`"pageNumber":"${pageNumber}"}`);
 
+      console.debug(`payload 4 is ${payload}`);
+    } else {
+      payload = payload.concat(`"pageNumber":"${pageNumber}"}`);
+    }
 
-      if (payload){
-          console.debug(`sending this payload to exporter: ${payload}`)
-          const response = await request(`${path}`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: payload
-          });
+    if (payload) {
+      console.debug(`sending this payload to exporter: ${payload}`);
+      const response = await request(`${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload
+      });
 
-          console.debug(`got back this response from exporter: ${response}`)
+      console.debug(`got back this response from exporter: ${response}`);
 
-          return response
-      }
-  }
-  }
+      return response;
+    }
+  };
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,50 +1,54 @@
 import request from './lib/request'
 
-const PATH = '/api/searchTools/transaction'
-
 export const DEFAULT_SORT = "orderId,asc"
 
 /**
  * Get a paginated list of transactions, returning a promise
- * 
+ *
  * @param  {number} pageNumber    The page number of transactions to get
- * @param  {number} pageSize      The number of transactions to get 
+ * @param  {number} pageSize      The number of transactions to get
  * @param  {string} sort          Properties to sort in the format sort=property,(asc|desc)
  * @param  {object} filterOptions Object containing options to search on for example:
  *    { siteId: 1, orderId: 'T12345', orderDate: ' }
- * 
+ *
  * @return {Page} The response data
  */
-export const list = async ({ pageNumber = 0, pageSize = 20, sort = DEFAULT_SORT, filterOptions, siteKey }) => {
-  let payload = `{"siteKey":"${siteKey}",`
-
-    if(filterOptions) {
-
-        for (var key in filterOptions) {
-            var value = filterOptions[key];
-            if(value) {
-                payload = payload.concat(`"${key}":"${value}",`)
-            }
-            console.log(key, value);
-        }
-        payload = payload.concat(`"pageNumber":"${pageNumber}"}`)
-
-        console.debug(`payload 4 is ${payload}` );
-    } else {
-        payload = payload.concat(`"pageNumber":"${pageNumber}"}`)
-    }
+export const list = getApiPath('/api/searchTools/transaction');
+export const count = getApiPath('/api/searchTools/transactionCounts');
 
 
-    if (payload){
-        console.debug(`sending this payload to exporter: ${payload}`)
-        const response = await request(`${PATH}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: payload
-        });
+  function getApiPath(path) {
+    return async ({ pageNumber = 0, pageSize = 20, sort = DEFAULT_SORT, filterOptions, siteKey }) => {
+    let payload = `{"siteKey":"${siteKey}",`
 
-        console.debug(`got back this response from exporter: ${response}`)
+      if(filterOptions) {
 
-        return response
-    }
-}
+          for (var key in filterOptions) {
+              var value = filterOptions[key];
+              if(value) {
+                  payload = payload.concat(`"${key}":"${value}",`)
+              }
+              console.log(key, value);
+          }
+          payload = payload.concat(`"pageNumber":"${pageNumber}"}`)
+
+          console.debug(`payload 4 is ${payload}` );
+      } else {
+          payload = payload.concat(`"pageNumber":"${pageNumber}"}`)
+      }
+
+
+      if (payload){
+          console.debug(`sending this payload to exporter: ${payload}`)
+          const response = await request(`${path}`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: payload
+          });
+
+          console.debug(`got back this response from exporter: ${response}`)
+
+          return response
+      }
+  }
+  }

--- a/src/components/TransactionFilter.js
+++ b/src/components/TransactionFilter.js
@@ -24,6 +24,7 @@ const useStyles = makeStyles(theme => ({
   card: {
     padding: theme.spacing(2),
     marginBottom: theme.spacing(2),
+    marginLeft: theme.spacing(2),
     minWidth: 500
   },
   cardActions: {
@@ -74,7 +75,7 @@ export default function TransactionFilter({ onApplyFilter, resultCounts }) {
         </Tooltip>
       </Toolbar>
       <Collapse in="false">
-        <Grid container direction="column" alignItems="center">
+        <Grid container direction="row" alignItems="top">
           <Card className={classes.card} variant="outlined">
             <CardContent>
               <Typography gutterBottom variant="h5" component="h2">

--- a/src/components/TransactionFilter.js
+++ b/src/components/TransactionFilter.js
@@ -33,14 +33,21 @@ const useStyles = makeStyles(theme => ({
   form: {
     display: 'flex',
     flexDirection: 'column'
+  },
+  textField: {
+    marginRight: "1rem"
+  },
+
+  dateFilter: {
+    marginTop: "1rem"
   }
 }));
 
-export default function TransactionFilter({onApplyFilter}) {
+export default function TransactionFilter({onApplyFilter, resultCounts}) {
   const classes = useStyles();
   const [visible, setVisible] = React.useState(false);
 
-  
+
   const handleSubmit = (event) => {
         event.preventDefault();
         var formElements = event.target.elements
@@ -64,7 +71,7 @@ export default function TransactionFilter({onApplyFilter}) {
           </IconButton>
         </Tooltip>
       </Toolbar>
-      <Collapse in={visible}>
+      <Collapse in="false">
         <Grid container direction="column" alignItems="center">
           <Card className={classes.card} variant="outlined">
             <CardContent>
@@ -72,70 +79,28 @@ export default function TransactionFilter({onApplyFilter}) {
                 Filter Options
               </Typography>
               <form id="transSearch" onSubmit={handleSubmit}>
-              <TextField id="orderId" label="External Order Id" />
-              <br/><br/>
-              <TextField id="emailAddress" label="User Email Address" />
+                <p><TextField id="orderId" label="External Order Id" /></p>
+              <p><TextField id="emailAddress" label="User Email Address" /></p>
+              <p><TextField id="productSku" label="Product SKU" /></p>
 
-              <br/><br/>
-              <TextField id="productSku" label="Product SKU" />
-    
-        <br/><br/>
+              <div className={classes.dateFilter}>
+              <p><TextField id="orderDateStart" label="Order Date From"
+                type="date" className={classes.textField} InputLabelProps={{ shrink: true }} />
+                <TextField id="orderDateEnd" label="Order Date To" type="date"
+                className={classes.textField} InputLabelProps={{ shrink: true }} />
+              </p>
 
-        <TextField
-    id="orderDateStart"
-    label="Order Date From"
-    type="date"
-    className={classes.textField}
-    InputLabelProps={{
-        shrink: true,
-    }}
-    />&nbsp;&nbsp;&nbsp;&nbsp;
-    <TextField
-    id="orderDateEnd"
-    label="Order Date To"
-    type="date"
-    className={classes.textField}
-    InputLabelProps={{
-        shrink: true,
-    }}
-    /><br/>
-    <TextField
-    id="deliveryDateStart"
-    label="Delivery Date From"
-    type="date"
-    className={classes.textField}
-    InputLabelProps={{
-        shrink: true,
-    }}
-    />&nbsp;&nbsp;&nbsp;&nbsp;
-    <TextField
-    id="deliveryDateEnd"
-    label="Delivery Date To"
-    type="date"
-    className={classes.textField}
-    InputLabelProps={{
-        shrink: true,
-    }}
-    /><br/>
+              <p><TextField id="deliveryDateStart" label="Delivery Date From" type="date"
+              className={classes.textField} InputLabelProps={{ shrink: true, }} />
+              <TextField id="deliveryDateEnd" label="Delivery Date To" type="date"
+              className={classes.textField} InputLabelProps={{ shrink: true }} />
+            </p>
 
-    <TextField
-    id="rseSendDateStart"
-    label="RSE Sent Date From"
-    type="date"
-    className={classes.textField}
-    InputLabelProps={{
-        shrink: true,
-    }}
-    />&nbsp;&nbsp;&nbsp;&nbsp;
-    <TextField
-    id="rseSendDateEnd"
-    label="RSE Sent Date To"
-    type="date"
-    className={classes.textField}
-    InputLabelProps={{
-        shrink: true,
-    }}
-    /><br/>
+            <p><TextField id="rseSendDateStart" label="RSE Sent Date From" type="date"
+            className={classes.textField} InputLabelProps={{ shrink: true }} />
+            <TextField id="rseSendDateEnd" label="RSE Sent Date To" type="date"
+            className={classes.textField} InputLabelProps={{ shrink: true }} /></p>
+      </div>
                 <CardActions className={classes.cardActions}>
                 <Button form="transSearch" type="submit" size="small" color="primary">
                   Apply
@@ -146,7 +111,23 @@ export default function TransactionFilter({onApplyFilter}) {
               </CardActions>
               </form>
             </CardContent>
-          
+
+          </Card>
+
+          <Card className={classes.card} variant="outlined">
+            <CardContent>
+              <Typography gutterBottom variant="h5" component="h2">
+                Key Figures
+              </Typography>
+              <p>{resultCounts.transactionCount} transactions found, involving {resultCounts.transactionsItemCount} items. {resultCounts.emailsSent} emails resulted in {resultCounts.transactionsWithReviews} reviews.</p>
+              <p>Of these {resultCounts.transactionCount} transactions:
+              <ul>
+                <li>{resultCounts.transactionsWithComments} had comments</li>
+                <li>{resultCounts.transactionsWithDeliveryDates} had delivery dates</li>
+                <li>{resultCounts.transactionsWithOptedOutUsers} involved opted-out users</li>
+              </ul>
+              </p>
+            </CardContent>
           </Card>
         </Grid>
       </Collapse>

--- a/src/components/TransactionFilter.js
+++ b/src/components/TransactionFilter.js
@@ -1,38 +1,38 @@
-import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
-import IconButton from '@material-ui/core/IconButton';
-import Tooltip from '@material-ui/core/Tooltip';
-import FilterListIcon from '@material-ui/icons/FilterList';
-import Collapse from '@material-ui/core/Collapse';
-import TextField from '@material-ui/core/TextField';
-import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import CardActions from '@material-ui/core/CardActions';
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Toolbar from "@material-ui/core/Toolbar";
+import Typography from "@material-ui/core/Typography";
+import IconButton from "@material-ui/core/IconButton";
+import Tooltip from "@material-ui/core/Tooltip";
+import FilterListIcon from "@material-ui/icons/FilterList";
+import Collapse from "@material-ui/core/Collapse";
+import TextField from "@material-ui/core/TextField";
+import Button from "@material-ui/core/Button";
+import Grid from "@material-ui/core/Grid";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardActions from "@material-ui/core/CardActions";
 
 const useStyles = makeStyles(theme => ({
   root: {
     paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(1),
+    paddingRight: theme.spacing(1)
   },
   title: {
-    flex: '1 1 100%',
+    flex: "1 1 100%"
   },
   card: {
     padding: theme.spacing(2),
     marginBottom: theme.spacing(2),
-    minWidth: 500,
+    minWidth: 500
   },
   cardActions: {
-    display: 'flex',
-    justifyContent: 'flex-end'
+    display: "flex",
+    justifyContent: "flex-end"
   },
   form: {
-    display: 'flex',
-    flexDirection: 'column'
+    display: "flex",
+    flexDirection: "column"
   },
   textField: {
     marginRight: "1rem"
@@ -43,21 +43,20 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-export default function TransactionFilter({onApplyFilter, resultCounts}) {
+export default function TransactionFilter({ onApplyFilter, resultCounts }) {
   const classes = useStyles();
   const [visible, setVisible] = React.useState(false);
 
+  const handleSubmit = event => {
+    event.preventDefault();
+    var formElements = event.target.elements;
+    var filterOptions = [];
+    Array.prototype.forEach.call(formElements, element => {
+      filterOptions[element.id] = element.value;
+    });
 
-  const handleSubmit = (event) => {
-        event.preventDefault();
-        var formElements = event.target.elements
-        var filterOptions=[]
-        Array.prototype.forEach.call(formElements, (element) => {
-            filterOptions[element.id] = element.value
-        })
-
-        onApplyFilter(filterOptions);
-  }
+    onApplyFilter(filterOptions);
+  };
 
   return (
     <>
@@ -66,7 +65,10 @@ export default function TransactionFilter({onApplyFilter, resultCounts}) {
           Transactions
         </Typography>
         <Tooltip title="Filter list">
-          <IconButton aria-label="filter list" onClick={() => setVisible(prev => !prev)}>
+          <IconButton
+            aria-label="filter list"
+            onClick={() => setVisible(prev => !prev)}
+          >
             <FilterListIcon />
           </IconButton>
         </Tooltip>
@@ -79,39 +81,81 @@ export default function TransactionFilter({onApplyFilter, resultCounts}) {
                 Filter Options
               </Typography>
               <form id="transSearch" onSubmit={handleSubmit}>
-                <p><TextField id="orderId" label="External Order Id" /></p>
-              <p><TextField id="emailAddress" label="User Email Address" /></p>
-              <p><TextField id="productSku" label="Product SKU" /></p>
+                <p>
+                  <TextField id="orderId" label="External Order Id" />
+                </p>
+                <p>
+                  <TextField id="emailAddress" label="User Email Address" />
+                </p>
+                <p>
+                  <TextField id="productSku" label="Product SKU" />
+                </p>
 
-              <div className={classes.dateFilter}>
-              <p><TextField id="orderDateStart" label="Order Date From"
-                type="date" className={classes.textField} InputLabelProps={{ shrink: true }} />
-                <TextField id="orderDateEnd" label="Order Date To" type="date"
-                className={classes.textField} InputLabelProps={{ shrink: true }} />
-              </p>
+                <div className={classes.dateFilter}>
+                  <p>
+                    <TextField
+                      id="orderDateStart"
+                      label="Order Date From"
+                      type="date"
+                      className={classes.textField}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                    <TextField
+                      id="orderDateEnd"
+                      label="Order Date To"
+                      type="date"
+                      className={classes.textField}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                  </p>
 
-              <p><TextField id="deliveryDateStart" label="Delivery Date From" type="date"
-              className={classes.textField} InputLabelProps={{ shrink: true, }} />
-              <TextField id="deliveryDateEnd" label="Delivery Date To" type="date"
-              className={classes.textField} InputLabelProps={{ shrink: true }} />
-            </p>
+                  <p>
+                    <TextField
+                      id="deliveryDateStart"
+                      label="Delivery Date From"
+                      type="date"
+                      className={classes.textField}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                    <TextField
+                      id="deliveryDateEnd"
+                      label="Delivery Date To"
+                      type="date"
+                      className={classes.textField}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                  </p>
 
-            <p><TextField id="rseSendDateStart" label="RSE Sent Date From" type="date"
-            className={classes.textField} InputLabelProps={{ shrink: true }} />
-            <TextField id="rseSendDateEnd" label="RSE Sent Date To" type="date"
-            className={classes.textField} InputLabelProps={{ shrink: true }} /></p>
-      </div>
+                  <p>
+                    <TextField
+                      id="rseSendDateStart"
+                      label="RSE Sent Date From"
+                      type="date"
+                      className={classes.textField}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                    <TextField
+                      id="rseSendDateEnd"
+                      label="RSE Sent Date To"
+                      type="date"
+                      className={classes.textField}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                  </p>
+                </div>
                 <CardActions className={classes.cardActions}>
-                <Button form="transSearch" type="submit" size="small" color="primary">
-                  Apply
-                </Button>
-                <Button size="small">
-                  Clear
-                </Button>
-              </CardActions>
+                  <Button
+                    form="transSearch"
+                    type="submit"
+                    size="small"
+                    color="primary"
+                  >
+                    Apply
+                  </Button>
+                  <Button size="small">Clear</Button>
+                </CardActions>
               </form>
             </CardContent>
-
           </Card>
 
           <Card className={classes.card} variant="outlined">
@@ -119,13 +163,25 @@ export default function TransactionFilter({onApplyFilter, resultCounts}) {
               <Typography gutterBottom variant="h5" component="h2">
                 Key Figures
               </Typography>
-              <p>{resultCounts.transactionCount} transactions found, involving {resultCounts.transactionsItemCount} items. {resultCounts.emailsSent} emails resulted in {resultCounts.transactionsWithReviews} reviews.</p>
-              <p>Of these {resultCounts.transactionCount} transactions:
-              <ul>
-                <li>{resultCounts.transactionsWithComments} had comments</li>
-                <li>{resultCounts.transactionsWithDeliveryDates} had delivery dates</li>
-                <li>{resultCounts.transactionsWithOptedOutUsers} involved opted-out users</li>
-              </ul>
+              <p>
+                {resultCounts.transactionCount} transactions found, involving{" "}
+                {resultCounts.transactionsItemCount} items.{" "}
+                {resultCounts.emailsSent} emails resulted in{" "}
+                {resultCounts.transactionsWithReviews} reviews.
+              </p>
+              <p>
+                Of these {resultCounts.transactionCount} transactions:
+                <ul>
+                  <li>{resultCounts.transactionsWithComments} had comments</li>
+                  <li>
+                    {resultCounts.transactionsWithDeliveryDates} had delivery
+                    dates
+                  </li>
+                  <li>
+                    {resultCounts.transactionsWithOptedOutUsers} involved
+                    opted-out users
+                  </li>
+                </ul>
               </p>
             </CardContent>
           </Card>
@@ -133,4 +189,4 @@ export default function TransactionFilter({onApplyFilter, resultCounts}) {
       </Collapse>
     </>
   );
-};
+}


### PR DESCRIPTION
The main effect of this PR is to add a "Key figures" panel to the transactions search interface: 

![image](https://user-images.githubusercontent.com/244541/112494103-20649300-8d59-11eb-85d7-b0a69b89ef93.png)

I also switched out some use of HTML for layout (`&nbsp;` and `<br/><br/>` tags) for CSS, and ran the Prettier JavaScript formatter over the changed files. 