### PR TITLE
Move this card out into its own component, and display numbers in a friendlier format

### DIFF
--- a/src/components/KeyFigures.js
+++ b/src/components/KeyFigures.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Typography from "@material-ui/core/Typography";
+
+function niceNum(n) {
+    if ("number" == typeof(n)) {
+        return n.toLocaleString('en');
+    } else {
+        return "an unknown number of";
+    }
+}
+
+export default function KeyFigures({ resultCounts }) {
+const useStyles = makeStyles(theme => ({
+  root: {
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(1)
+  },
+  title: {
+    flex: "1 1 100%"
+  },
+  card: {
+    padding: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    marginLeft: theme.spacing(2),
+      minWidth: 500,
+      maxWidth: `calc(50% - ${theme.spacing(2)}px)`
+  },
+  cardActions: {
+    display: "flex",
+    justifyContent: "flex-end"
+  },
+  form: {
+    display: "flex",
+    flexDirection: "column"
+  },
+  textField: {
+    marginRight: "1rem"
+  },
+
+  dateFilter: {
+    marginTop: "1rem"
+  },
+    ul: {
+        marginTop: theme.spacing(1),
+        marginLeft: theme.spacing(2),
+    listStyleType: "disc"
+}
+}));
+
+
+  const classes = useStyles();
+
+    return <Card className={classes.card} variant="outlined">
+            <CardContent>
+              <Typography gutterBottom variant="h5" component="h2">
+                Key Figures
+              </Typography>
+              <p>
+                {niceNum(resultCounts.transactionCount)} transactions found, involving{" "}
+                {niceNum(resultCounts.transactionsItemCount)} items.{" "}
+                {niceNum(resultCounts.emailsSent)} emails resulted in{" "}
+                {niceNum(resultCounts.transactionsWithReviews)} reviews.
+              </p>
+              <p>
+                Of these {niceNum(resultCounts.transactionCount)} transactions:
+                <ul className={classes.ul}>
+                  <li>{niceNum(resultCounts.transactionsWithComments)} had comments</li>
+                  <li>
+                    {niceNum(resultCounts.transactionsWithDeliveryDates)} had delivery
+                    dates
+                  </li>
+                  <li>
+                    {niceNum(resultCounts.transactionsWithOptedOutUsers)} involved
+                    opted-out users
+                  </li>
+                </ul>
+              </p>
+            </CardContent>
+            </Card>;
+}

--- a/src/components/KeyFigures.js
+++ b/src/components/KeyFigures.js
@@ -5,79 +5,82 @@ import CardContent from "@material-ui/core/CardContent";
 import Typography from "@material-ui/core/Typography";
 
 function niceNum(n) {
-    if ("number" == typeof(n)) {
-        return n.toLocaleString('en');
-    } else {
-        return "an unknown number of";
-    }
+  if ("number" == typeof n) {
+    return n.toLocaleString("en");
+  } else {
+    return "an unknown number of";
+  }
 }
 
 export default function KeyFigures({ resultCounts }) {
-const useStyles = makeStyles(theme => ({
-  root: {
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(1)
-  },
-  title: {
-    flex: "1 1 100%"
-  },
-  card: {
-    padding: theme.spacing(2),
-    marginBottom: theme.spacing(2),
-    marginLeft: theme.spacing(2),
+  const useStyles = makeStyles(theme => ({
+    root: {
+      paddingLeft: theme.spacing(2),
+      paddingRight: theme.spacing(1)
+    },
+    title: {
+      flex: "1 1 100%"
+    },
+    card: {
+      padding: theme.spacing(2),
+      marginBottom: theme.spacing(2),
+      marginLeft: theme.spacing(2),
       minWidth: 500,
       maxWidth: `calc(50% - ${theme.spacing(2)}px)`
-  },
-  cardActions: {
-    display: "flex",
-    justifyContent: "flex-end"
-  },
-  form: {
-    display: "flex",
-    flexDirection: "column"
-  },
-  textField: {
-    marginRight: "1rem"
-  },
+    },
+    cardActions: {
+      display: "flex",
+      justifyContent: "flex-end"
+    },
+    form: {
+      display: "flex",
+      flexDirection: "column"
+    },
+    textField: {
+      marginRight: "1rem"
+    },
 
-  dateFilter: {
-    marginTop: "1rem"
-  },
+    dateFilter: {
+      marginTop: "1rem"
+    },
     ul: {
-        marginTop: theme.spacing(1),
-        marginLeft: theme.spacing(2),
-    listStyleType: "disc"
-}
-}));
-
+      marginTop: theme.spacing(1),
+      marginLeft: theme.spacing(2),
+      listStyleType: "disc"
+    }
+  }));
 
   const classes = useStyles();
 
-    return <Card className={classes.card} variant="outlined">
-            <CardContent>
-              <Typography gutterBottom variant="h5" component="h2">
-                Key Figures
-              </Typography>
-              <p>
-                {niceNum(resultCounts.transactionCount)} transactions found, involving{" "}
-                {niceNum(resultCounts.transactionsItemCount)} items.{" "}
-                {niceNum(resultCounts.emailsSent)} emails resulted in{" "}
-                {niceNum(resultCounts.transactionsWithReviews)} reviews.
-              </p>
-              <p>
-                Of these {niceNum(resultCounts.transactionCount)} transactions:
-                <ul className={classes.ul}>
-                  <li>{niceNum(resultCounts.transactionsWithComments)} had comments</li>
-                  <li>
-                    {niceNum(resultCounts.transactionsWithDeliveryDates)} had delivery
-                    dates
-                  </li>
-                  <li>
-                    {niceNum(resultCounts.transactionsWithOptedOutUsers)} involved
-                    opted-out users
-                  </li>
-                </ul>
-              </p>
-            </CardContent>
-            </Card>;
+  return (
+    <Card className={classes.card} variant="outlined">
+      <CardContent>
+        <Typography gutterBottom variant="h5" component="h2">
+          Key Figures
+        </Typography>
+        <p>
+          {niceNum(resultCounts.transactionCount)} transactions found, involving{" "}
+          {niceNum(resultCounts.transactionsItemCount)} items.{" "}
+          {niceNum(resultCounts.emailsSent)} emails resulted in{" "}
+          {niceNum(resultCounts.transactionsWithReviews)} reviews.
+        </p>
+        <p>
+          Of these {niceNum(resultCounts.transactionCount)} transactions:
+          <ul className={classes.ul}>
+            <li>
+              {niceNum(resultCounts.transactionsWithComments)} had comments
+            </li>
+            <li>
+              {niceNum(resultCounts.transactionsWithDeliveryDates)} had delivery
+              dates
+            </li>
+            <li>
+              {niceNum(resultCounts.transactionsWithOptedOutUsers)} involved
+              opted-out users
+            </li>
+          </ul>
+        </p>
+      </CardContent>
+    </Card>
+  );
 }

--- a/src/components/TransactionFilter.js
+++ b/src/components/TransactionFilter.js
@@ -13,6 +13,8 @@ import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import CardActions from "@material-ui/core/CardActions";
 
+import KeyFigures from "./KeyFigures";
+
 const useStyles = makeStyles(theme => ({
   root: {
     paddingLeft: theme.spacing(2),
@@ -158,34 +160,7 @@ export default function TransactionFilter({ onApplyFilter, resultCounts }) {
               </form>
             </CardContent>
           </Card>
-
-          <Card className={classes.card} variant="outlined">
-            <CardContent>
-              <Typography gutterBottom variant="h5" component="h2">
-                Key Figures
-              </Typography>
-              <p>
-                {resultCounts.transactionCount} transactions found, involving{" "}
-                {resultCounts.transactionsItemCount} items.{" "}
-                {resultCounts.emailsSent} emails resulted in{" "}
-                {resultCounts.transactionsWithReviews} reviews.
-              </p>
-              <p>
-                Of these {resultCounts.transactionCount} transactions:
-                <ul>
-                  <li>{resultCounts.transactionsWithComments} had comments</li>
-                  <li>
-                    {resultCounts.transactionsWithDeliveryDates} had delivery
-                    dates
-                  </li>
-                  <li>
-                    {resultCounts.transactionsWithOptedOutUsers} involved
-                    opted-out users
-                  </li>
-                </ul>
-              </p>
-            </CardContent>
-          </Card>
+          <KeyFigures resultCounts={resultCounts} />
         </Grid>
       </Collapse>
     </>


### PR DESCRIPTION
This PR moves some code out into its own component, and adds commas when displaying numbers. (If a "null" comes back in the JSON, then we'll display a friendly string instead.) 

![image](https://user-images.githubusercontent.com/244541/112511618-f9ae5880-8d68-11eb-890c-231507066e6b.png)
